### PR TITLE
AI: Change Front Page Text to Welsh

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,5 @@
 class ApplicationController < ActionController::Base
   def index
-    render json: { message: 'Hello, world!, v2' }
+    render json: { message: 'Helo, byd!, v2' }
   end
 end

--- a/app/javascript/controllers/hello_controller.js
+++ b/app/javascript/controllers/hello_controller.js
@@ -2,6 +2,6 @@ import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
   connect() {
-    this.element.textContent = "Hello World!"
+    this.element.textContent = "Helo Byd!"
   }
 }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -28,4 +28,4 @@
 #       enabled: "ON"
 
 en:
-  hello: "Hello world"
+  hello: "Helo byd"


### PR DESCRIPTION
## AI-Generated Implementation

This PR was generated by AI to implement: Change Front Page Text to Welsh

Fixes #230

### Original Specification
## Title
Change Front Page Text to Welsh

## Description
Update the text displayed on the front page of the website to be in Welsh.

## User Story
- As a merchant
- I want the front page text to be in Welsh
- so that Welsh-speaking customers can understand the content.

## Acceptance Criteria
- All front page text is translated to Welsh.
- The layout remains consistent after the text change.

## Technical Details
N/A

## Design
N/A

### Priority Rationale
This change is important to enhance accessibility for Welsh-speaking users and improve their experience on the site.

### Implementation Notes
- Generated from WorkItem #ef53ad89-59c2-46fb-9c4d-8ff8aa47d98f
- Original prompt: WorkItem #0c0eb79c-ce2f-4f92-a57b-5c8488a1ddab
