### PR TITLE
AI: Translate README into Japanese

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,0 +1,17 @@
+# Symmertrical Lamp テストアプリ
+
+このアプリをBuild.ioに2クリックでデプロイ（カスタマイズ可能）：
+
+<p>
+  <a href="https://app.adamantium.io/deploy/?template=matthewchigira/symmetrical-lamp">
+    <img src="https://raw.githubusercontent.com/matthewchigira/symmetrical-lamp/main/deploy-to-build-button.svg" alt="Deploy" width="150px">
+  </a>
+</p>
+
+このアプリをBuild.ioに1クリックでデプロイ（エクスプレスモード - すべてのデフォルト設定を使用）：
+
+<p>
+  <a href="https://app.adamantium.io/deploy/?template=matthewchigira/symmetrical-lamp&express=true">
+    <img src="https://raw.githubusercontent.com/matthewchigira/symmetrical-lamp/main/deploy-to-build-button.svg" alt="Deploy" width="150px">
+  </a>
+</p>


### PR DESCRIPTION
## AI-Generated Implementation

This PR was generated by AI to implement: Translate README into Japanese

Fixes #340

### Original Specification
## Title
Translate README into Japanese

## Description
The README file needs to be translated from English to Japanese to ensure accessibility for Japanese-speaking users.

## User Story
- As a merchant
- I want the README to be available in Japanese
- so that Japanese-speaking users can understand the product better

## Acceptance Criteria
- The README is fully translated into Japanese
- The translation is accurate and maintains the original meaning
- The translated README is reviewed for clarity and correctness

## Technical Details
N/A

## Design
N/A

### Priority Rationale
This task is essential for improving user experience and accessibility for Japanese-speaking merchants.

### Implementation Notes
- Generated from WorkItem #4e79c98b-a9b2-42c0-9669-a19945f933f6
- Original prompt: WorkItem #f2cc15ae-c53c-4265-88c6-afebe6a3e286
